### PR TITLE
Update self.date manually as vue reactivity system may not have updat…

### DIFF
--- a/frontend/js/components/DatePicker.vue
+++ b/frontend/js/components/DatePicker.vue
@@ -177,6 +177,7 @@
 
           },
           onClose: function (selectedDates, dateStr, instance) {
+            self.date = dateStr; // update Vue data manually as vue may not have updated self.date yet
             self.$nextTick(function () { // wait for the datepicker to properly update the UI
               self.$emit('input', self.date)
               self.$emit('close', self.date)


### PR DESCRIPTION
The value of DatePicker form fields does not always update to the selected value.
 
Update self.date manually as vue reactivity system may not have updated it yet to ensure the selected value persists.